### PR TITLE
Use environment files for setOutput and saveState

### DIFF
--- a/lib/src/core/core.dart
+++ b/lib/src/core/core.dart
@@ -104,13 +104,20 @@ bool getBooleanInput({
 
 /// Sets the value of an output.
 void setOutput({required String name, required Object value}) {
-  output.writeln('');
+  final filePath = Platform.environment['GITHUB_OUTPUT'] ?? '';
+  final message = value is String ? value : jsonEncode(value);
 
-  issueCommand(
-    'set-output',
-    {'name': name},
-    value is String ? value : jsonEncode(value),
-  );
+  if (filePath.isNotEmpty) {
+    issueFileCommand('OUTPUT', '$name=$message');
+  } else {
+    output.writeln('');
+
+    issueCommand(
+      'set-output',
+      {'name': name},
+      message,
+    );
+  }
 }
 
 /// Enables or disables the echoing of commands into stdout for the rest of the step.
@@ -208,11 +215,18 @@ void saveState({
   required String name,
   required Object value,
 }) {
-  issueCommand(
-    'save-state',
-    {'name': name},
-    value is String ? value : jsonEncode(value),
-  );
+  final filePath = Platform.environment['GITHUB_STATE'] ?? '';
+  final message = value is String ? value : jsonEncode(value);
+
+  if (filePath.isNotEmpty) {
+    issueFileCommand('STATE', '$name=$message');
+  } else {
+    issueCommand(
+      'save-state',
+      {'name': name},
+      message,
+    );
+  }
 }
 
 /// Gets the value of an state set by this action's main execution.

--- a/test/src/core/core_test.dart
+++ b/test/src/core/core_test.dart
@@ -251,7 +251,7 @@ void main() {
       );
     });
 
-    test('setOutput produces the correct command', () {
+    test('legacy setOutput produces the correct command', () {
       core.setOutput(name: 'some output', value: 'some value');
 
       expect(
@@ -260,7 +260,7 @@ void main() {
       );
     });
 
-    test('setOutput handles bools', () {
+    test('legacy setOutput handles bools', () {
       core.setOutput(name: 'some output', value: false);
 
       expect(
@@ -269,7 +269,7 @@ void main() {
       );
     });
 
-    test('setOutput handles numbers', () {
+    test('legacy setOutput handles numbers', () {
       core.setOutput(name: 'some output', value: 1.01);
 
       expect(
@@ -469,7 +469,7 @@ void main() {
       );
     });
 
-    test('saveState produces the correct command', () {
+    test('legacy saveState produces the correct command', () {
       core.saveState(name: 'state_1', value: 'some value');
 
       expect(
@@ -478,7 +478,7 @@ void main() {
       );
     });
 
-    test('saveState handles numbers', () {
+    test('legacy saveState handles numbers', () {
       core.saveState(name: 'state_1', value: 1);
 
       expect(
@@ -487,7 +487,7 @@ void main() {
       );
     });
 
-    test('saveState handles bools', () {
+    test('legacy saveState handles bools', () {
       core.saveState(name: 'state_1', value: true);
 
       expect(


### PR DESCRIPTION
# What is the purpose of this pull request? (put an "X" next to an item)

[X] Bug fix

Closes #42 

## What changes did you make? (Give an overview)

- Changed the `setOutput` and `saveState` function to use environment files instead of the deprecated `set-output` and `save-state` commands.

## Is there anything you'd like reviewers to focus on?

No tests were added because existing functionality using environment files is not tested either - should we add some?
